### PR TITLE
Add WithRetry option

### DIFF
--- a/cmd/protoc-gen-go-nats/version.go
+++ b/cmd/protoc-gen-go-nats/version.go
@@ -1,2 +1,2 @@
 package main
-var version = "v0.1.6"
+var version = "v0.1.7"


### PR DESCRIPTION
Calls are only actually retried when there was a NoResponders error, so that when the server might've not yet started up fully - and not for broadcasting calls nor status verbs.

Closes #10.